### PR TITLE
Add principal layer init methods 

### DIFF
--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -1,4 +1,4 @@
-use super::{Ancestor, Broadcasted, GraphBuilder, Parameters, Tensor};
+use super::{Broadcasted, GraphBuilder, ParamDim, Parameters, Tensor};
 use ndarray::{
     concatenate, linalg::general_mat_mul, linalg::general_mat_vec_mul, stack, Array2, ArrayView1,
     Axis, DimMax, Dimension, Ix1, Ix2, RemoveAxis, Zip,
@@ -190,7 +190,7 @@ where
 
 impl<D> Parameter<D>
 where
-    D: Ancestor,
+    D: ParamDim,
 {
     pub fn new(data: Tensor<D>) -> GraphBuilder<Self, D> {
         let grad = Tensor::zeros(data.raw_dim());

--- a/src/nn/mod.rs
+++ b/src/nn/mod.rs
@@ -1,27 +1,118 @@
 pub mod init {
+    use super::super::{graph::GraphBuilder, graph::ParamDim, Parameter};
+    use ndarray::{Axis, Ix2};
+    use rand::thread_rng;
+    use rand_distr::{Distribution, Normal, Uniform};
 
-    // Returns the recommended gain value for the given nonlinearity function.
-    pub fn calculate_gain(non_linearity: &str, param: Option<f32>) -> f32 {
-        match (non_linearity, param) {
-            ("linear", None) | ("sigmoid", None) => 1.0,
-            ("tanh", None) => 5.0 / 3.0,
-            ("relu", None) => 2.0_f32.sqrt(),
-            ("leaky_relu", Some(param_val)) => {
-                let slope = param_val;
-                (2.0 / (1.0 + slope.powi(2))).sqrt()
+    /// Returns the recommended gain value for the given nonlinearity function.
+    pub fn calculate_gain(non_linearity: &str) -> f32 {
+        match non_linearity {
+            "linear" | "sigmoid" => 1.0,
+            "tanh" => 5.0 / 3.0,
+            "relu" => 2.0_f32.sqrt(),
+            "leaky_relu" => (2.0 / (1.0 + 0.01_f32.powi(2))).sqrt(),
+            _ => panic!("error: unsupported nonlinearity: {}", non_linearity),
+        }
+    }
+
+    /// For MLPs `fan_in` and `fan_out` are respectively the number of
+    /// inputs and outputs to an hidden unit of the layer.
+    /// For CNNs however, the number of input feature maps and
+    /// the size of the receptive field must be taken into account .
+    fn calculate_fan_in_fan_out<D: ParamDim>(param: &GraphBuilder<Parameter<D>, D>) -> (f32, f32) {
+        let data = param.data();
+        let shape = data.shape();
+
+        let num_input_fmaps = shape[1] as f32;
+        let num_output_fmaps = shape[0] as f32;
+        let mut receptive_field_size = 1.;
+
+        let no_dim = data.ndim();
+        let mut num_el = 0;
+        if no_dim > 2 {
+            for dim in 2..no_dim {
+                num_el += data.len_of(Axis(dim));
             }
-            _ => {
-                if let Some(p) = param {
-                    panic!(
-                        "error: unsupported nonlinearity: {} with param: {}.",
-                        non_linearity, p
-                    )
-                } else {
-                    panic!("error: this nonlinearity: {} needs a param.", non_linearity)
-                }
+            receptive_field_size = num_el as f32;
+        }
+
+        let fan_in = num_input_fmaps * receptive_field_size;
+        let fan_out = num_output_fmaps * receptive_field_size;
+        (fan_in, fan_out)
+    }
+
+    /// Fills the input `Parameter` with `value`.
+    pub fn constant<D: ParamDim>(param: &mut GraphBuilder<Parameter<D>, D>, value: f32) {
+        param.data_mut().map_inplace(|el| *el = value);
+    }
+
+    /// Fills the input `Parameter` with `0.0`.
+    pub fn zeros<D: ParamDim>(param: &mut GraphBuilder<Parameter<D>, D>) {
+        param.data_mut().map_inplace(|el| *el = 0.);
+    }
+
+    /// Fills the input `Parameter` with `1.0`.
+    pub fn ones<D: ParamDim>(param: &mut GraphBuilder<Parameter<D>, D>) {
+        param.data_mut().map_inplace(|el| *el = 1.0);
+    }
+
+    /// Fills the 2-dimensional input `Parameter` with the identity matrix.
+    /// Preserves the identity of the inputs in Linear layers, where as
+    /// many inputs are preserved as possible.
+    pub fn eye(param: &mut GraphBuilder<Parameter<Ix2>, Ix2>) {
+        for ((x, y), el) in param.data_mut().indexed_iter_mut() {
+            if x == y {
+                *el = 1.
+            } else {
+                *el = 0.
             }
         }
     }
-    // TODO: layers' init functions.
-    // See https://pytorch.org/docs/stable/nn.init.html
+
+    /// Fills the input `Parameter` with elements drawn from
+    /// the uniform distribution U(low, high).
+    pub fn uniform<D: ParamDim>(param: &mut GraphBuilder<Parameter<D>, D>, low: f32, high: f32) {
+        let unif_dstr = Uniform::new(low, high);
+        param
+            .data_mut()
+            .map_inplace(|el| *el = unif_dstr.sample(&mut thread_rng()));
+    }
+
+    /// Fills the input `Parameter` with elements drawn from
+    /// the normal distribution N(mean, std^2).
+    pub fn normal<D: ParamDim>(param: &mut GraphBuilder<Parameter<D>, D>, mean: f32, std: f32) {
+        let norm_dstr = Normal::new(mean, std).unwrap();
+        param
+            .data_mut()
+            .map_inplace(|el| *el = norm_dstr.sample(&mut thread_rng()));
+    }
+
+    /// Fills the input `Parameter` with values according to the method
+    /// described in Understanding the difficulty of training deep feedforward
+    /// neural networks - Glorot, X. & Bengio, Y. (2010), using a uniform
+    /// distribution.
+    pub fn xavier_uniform<D: ParamDim>(param: &mut GraphBuilder<Parameter<D>, D>, gain: f32) {
+        let (fan_in, fan_out) = calculate_fan_in_fan_out(param);
+        let std = gain * (2. / ((fan_in + fan_out) as f32)).sqrt();
+        let a = 3.0_f32.sqrt() * std;
+        let unif_distr = Uniform::new(-a, a);
+        param
+            .data_mut()
+            .map_inplace(|el| *el = unif_distr.sample(&mut thread_rng()));
+    }
+
+    /// Fills the input `Parameter` with values according to the method
+    /// described in Understanding the difficulty of training deep feedforward
+    /// neural networks - Glorot, X. & Bengio, Y. (2010), using a normal
+    /// distribution.
+    ///
+    /// Also known as Glorot initialization.
+    pub fn xavier_normal<D: ParamDim>(param: &mut GraphBuilder<Parameter<D>, D>, gain: f32) {
+        let (fan_in, fan_out) = calculate_fan_in_fan_out(param);
+        let std = gain * (2. / ((fan_in + fan_out) as f32)).sqrt();
+        let norm_distr = Normal::new(0., std).unwrap();
+        param
+            .data_mut()
+            .map_inplace(|el| *el = norm_distr.sample(&mut thread_rng()));
+    }
 }


### PR DESCRIPTION
### Content
This PR adds the following layer init methods specified in #17:

- `ones`
- `zeros`
- `constant`
- `eye`
- `normal`
- `uniform`
- `Xavier normal`
- `Xavier uniform`

### Additional Info
I have chosen not to return a new Parameter struct in order to decouple the initialisation of the parameter from the creation of the parameter, the main advantage of following this approach in my opinion is that the user has to specify the shape of the parameter to be created only once upon the layer's instantiation.