### PR TITLE
Modify .split()

### DIFF
--- a/src/nn/convolution.rs
+++ b/src/nn/convolution.rs
@@ -3376,8 +3376,6 @@ mod tests {
 
         #[test]
         fn replication_pad_1d() {
-            use PaddingMode;
-
             let padding = Replicative;
             let arr = ndarray::Array::range(0., 5., 1.);
             let padded = padding.pad(&arr, [2]);
@@ -3386,8 +3384,6 @@ mod tests {
 
         #[test]
         fn replication_pad_2d() {
-            use PaddingMode;
-
             let padding = Replicative;
             let arr = ndarray::Array::range(0., 25., 1.)
                 .into_shape((5, 5))
@@ -3409,8 +3405,6 @@ mod tests {
 
         #[test]
         fn replication_pad_3d() {
-            use PaddingMode;
-
             let padding = Replicative;
             let arr = ndarray::Array::range(0., 125., 1.)
                 .into_shape((5, 5, 5))
@@ -3502,8 +3496,6 @@ mod tests {
 
         #[test]
         fn reflection_pad_1d() {
-            use PaddingMode;
-
             let padding = Reflective;
             let arr = ndarray::Array::range(0., 5., 1.);
             let padded = padding.pad(&arr, [2]);
@@ -3512,8 +3504,6 @@ mod tests {
 
         #[test]
         fn reflection_pad_2d() {
-            use PaddingMode;
-
             let padding = Reflective;
             let arr = ndarray::Array::range(0., 25., 1.)
                 .into_shape((5, 5))
@@ -3535,8 +3525,6 @@ mod tests {
 
         #[test]
         fn reflection_pad_3d() {
-            use PaddingMode;
-
             let padding = Reflective;
             let arr = ndarray::Array::range(0., 125., 1.)
                 .into_shape((5, 5, 5))
@@ -3829,7 +3817,7 @@ mod tests {
 
         #[test]
         fn conv3d() {
-            let input_elems = Array::<f32, _>::from_iter((0..750).map(|el| el as f32));
+            let input_elems = (0..750).map(|el| el as f32).collect::<Array<f32, _>>();
             let input = input_elems.into_shape((2, 3, 5, 5, 5)).unwrap();
             let kernel = Array::<f32, _>::ones((4, 3, 2, 2, 2));
 
@@ -4177,7 +4165,7 @@ mod tests {
 
         #[test]
         fn conv3d_strided() {
-            let input_elems = Array::<f32, _>::from_iter((0..750).map(|el| el as f32));
+            let input_elems = (0..750).map(|el| el as f32).collect::<Array<f32, _>>();
             let input = input_elems.into_shape((2, 3, 5, 5, 5)).unwrap();
             let kernel = Array::<f32, _>::ones((4, 3, 2, 2, 2));
 
@@ -4477,7 +4465,7 @@ mod tests {
 
         #[test]
         fn conv3d_dilated() {
-            let input_elems = Array::<f32, _>::from_iter((0..750).map(|el| el as f32));
+            let input_elems = (0..750).map(|el| el as f32).collect::<Array<f32, _>>();
             let input = input_elems.into_shape((2, 3, 5, 5, 5)).unwrap();
             let kernel = Array::<f32, _>::ones((4, 3, 2, 2, 2));
 
@@ -4956,7 +4944,7 @@ mod tests {
 
         #[test]
         fn grouped_conv3d() {
-            let input_elems = Array::<f32, _>::from_iter((0..2000).map(|el| el as f32));
+            let input_elems = (0..2_000).map(|el| el as f32).collect::<Array<f32, _>>();
             let input = input_elems.into_shape((2, 8, 5, 5, 5)).unwrap();
             let kernel = Array::<f32, _>::ones((16, 2, 2, 2, 2));
 

--- a/src/nn/loss.rs
+++ b/src/nn/loss.rs
@@ -1608,7 +1608,7 @@ mod test {
         ));
         input.forward();
 
-        let loss = NLLLoss::new(input.clone(), target.clone(), Reduction::Mean);
+        let loss = NLLLoss::new(input, target.clone(), Reduction::Mean);
 
         loss.forward();
         assert_almost_equals(&*loss.data(), &new_tensor(1, vec![1.52222]));
@@ -1652,7 +1652,7 @@ mod test {
         ));
         input.forward();
 
-        let loss = NLLLoss::new(input.clone(), target.clone(), Reduction::Sum);
+        let loss = NLLLoss::new(input, target.clone(), Reduction::Sum);
 
         loss.forward();
         assert_almost_equals(&*loss.data(), &new_tensor(1, vec![4.56666]));

--- a/src/nn/mod.rs
+++ b/src/nn/mod.rs
@@ -425,7 +425,7 @@ impl ModelStatus {
     ///
     /// Usually the result of this method is passed to an optimizer.
     pub fn parameters(&self) -> Vec<Param> {
-        self.params.iter().cloned().collect()
+        self.params.to_vec()
     }
 
     /// Registers a component.

--- a/src/variable/node/backward.rs
+++ b/src/variable/node/backward.rs
@@ -6760,6 +6760,7 @@ mod tests {
             assert_eq!(diff.can_overwrite(), false);
         }
 
+        #[allow(clippy::clippy::approx_constant)]
         #[test]
         fn backward() {
             let diff = new_backward_input(3, vec![0.; 3]);
@@ -6834,6 +6835,7 @@ mod tests {
             assert_eq!(diff.can_overwrite(), false);
         }
 
+        #[allow(clippy::clippy::approx_constant)]
         #[test]
         fn backward() {
             let diff = new_backward_input((10, 10), vec![0.; 100]);

--- a/src/variable/node/forward.rs
+++ b/src/variable/node/forward.rs
@@ -2874,6 +2874,7 @@ mod tests {
             assert_eq!(node.was_computed(), false);
         }
 
+        #[allow(clippy::clippy::approx_constant)]
         #[test]
         fn forward() {
             let input = new_input((3, 3), vec![1., 2., 3., 4., 5., 6., 7., 8., 9.]);


### PR DESCRIPTION
- Changed behavior of `split`, now it's non-randomic
- Fixed some minor `Clippy` warnings